### PR TITLE
 Add Caius' macos flavour to pegasushoof

### DIFF
--- a/keyboards/bpiphany/pegasushoof/config.h
+++ b/keyboards/bpiphany/pegasushoof/config.h
@@ -21,8 +21,8 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 #include "config_common.h"
 
 /* USB Device descriptor parameter */
-#define VENDOR_ID       0xFEED
-#define PRODUCT_ID      0x6050
+#define VENDOR_ID       0x05ac // Apple Inc
+#define PRODUCT_ID      0x021e // Aluminum Compact Keyboard (ISO)
 #define DEVICE_VER      0x0104
 #define MANUFACTURER    Filco
 #define PRODUCT         Majestouch TKL \\w The Pegasus Hoof

--- a/keyboards/bpiphany/pegasushoof/keymaps/caius-macos/keymap.c
+++ b/keyboards/bpiphany/pegasushoof/keymaps/caius-macos/keymap.c
@@ -1,0 +1,56 @@
+/*
+Copyright 2019 Caius Durling <dev@caius.name>
+
+This program is free software: you can redistribute it and/or modify
+it under the terms of the GNU General Public License as published by
+the Free Software Foundation, either version 2 of the License, or
+(at your option) any later version.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with this program.  If not, see <http://www.gnu.org/licenses/>.
+*/
+
+#include QMK_KEYBOARD_H
+
+#define KM_QWERTY  0
+#define KM_FUNCT   1
+
+const uint16_t PROGMEM keymaps[][MATRIX_ROWS][MATRIX_COLS] = {
+  /* Layer 0: Standard ISO layer with media keys */
+  [KM_QWERTY] = LAYOUT( \
+    KC_ESC,           KC_F1, KC_F2, KC_F3,   KC_F4,   KC_F5,   KC_F6,   KC_F7, KC_F8, KC_F9, KC_F10, KC_F11, KC_F12, _______, _______, KC_POWER, \
+    KC_NUBS,  KC_1,    KC_2,    KC_3,    KC_4,    KC_5,    KC_6,    KC_7,    KC_8,    KC_9,    KC_0,    KC_MINS, KC_EQL,  KC_BSPC,  KC_APFN,   KC_HOME, KC_PGUP, \
+    KC_TAB,  KC_Q,    KC_W,    KC_E,    KC_R,    KC_T,    KC_Y,    KC_U,    KC_I,    KC_O,    KC_P,    KC_LBRC, KC_RBRC, KC_BSLS,    KC_DEL,  KC_END,  KC_PGDN, \
+    KC_CLCK, KC_A,    KC_S,    KC_D,    KC_F,    KC_G,    KC_H,    KC_J,    KC_K,    KC_L,    KC_SCLN, KC_QUOT,          KC_ENT,                                \
+    KC_LSFT, KC_GRV, KC_Z,    KC_X,    KC_C,    KC_V,    KC_B,    KC_N,    KC_M,    KC_COMM, KC_DOT,  KC_SLSH,          KC_RSFT,             KC_UP,            \
+    KC_LCTL, KC_LALT, KC_LGUI,                            KC_SPC,                             KC_PENT, KC_RGUI, KC_RALT, KC_RCTL,      KC_LEFT, KC_DOWN, KC_RGHT  \
+  ),
+  /* Layer 1: Function layer */
+  [KM_FUNCT] = LAYOUT( \
+    _______,           KC_F1,   KC_F2,   KC_F3,   KC_F4,   KC_F5,   KC_F6,   KC_F7,   KC_F8,   KC_F9,   KC_F10,  KC_F11,  KC_F12,    _______, _______, _______, \
+    _______, _______, _______, _______, _______, _______, _______, _______, _______, _______, _______, _______, _______, _______,    _______, _______, KC_VOLU, \
+    _______, _______, _______, _______, _______, _______, _______, _______, _______, _______, _______, _______, _______, _______,    _______, _______, KC_VOLD, \
+    _______, _______, _______, _______, _______, _______, _______, _______, _______, _______, _______, _______,          _______,                               \
+    _______, _______, _______, _______, _______, _______, _______, _______, _______, _______, _______, _______,          _______,             KC_MPLY,          \
+    _______, _______, _______,                            _______,                            _______, _______, RESET,   _______,    KC_MPRV, KC_MSTP, KC_MNXT  \
+  )
+};
+
+void led_set_user(uint8_t usb_led) {
+  if (usb_led & (1 << USB_LED_CAPS_LOCK)) {
+    ph_caps_led_on();
+  } else {
+    ph_caps_led_off();
+  }
+
+  if (usb_led & (1 << USB_LED_SCROLL_LOCK)) {
+    ph_sclk_led_on();
+  } else {
+    ph_sclk_led_off();
+  }
+}

--- a/keyboards/bpiphany/pegasushoof/keymaps/caius-macos/rules.mk
+++ b/keyboards/bpiphany/pegasushoof/keymaps/caius-macos/rules.mk
@@ -1,0 +1,18 @@
+# Build Options
+#   change to "no" to disable the options, or define them in the Makefile in
+#   the appropriate keymap folder that will get included automatically
+#
+APPLE_FN_ENABLE = yes       # Apple fn key please
+BOOTMAGIC_ENABLE = no       # Virtual DIP switch configuration(+1000)
+MOUSEKEY_ENABLE = no        # Mouse keys(+4700)
+EXTRAKEY_ENABLE = yes       # Audio control and System control(+450)
+CONSOLE_ENABLE = no         # Console for debug(+400)
+COMMAND_ENABLE = no         # Commands for debug and configuration
+CUSTOM_MATRIX = yes         # Custom matrix file for the Pegasus Hoof due to the 2x74HC42
+NKRO_ENABLE = no            # Nkey Rollover - if this doesn't work, see here: https://github.com/tmk/tmk_keyboard/wiki/FAQ#nkro-doesnt-work
+BACKLIGHT_ENABLE = no       # Enable keyboard backlight functionality
+MIDI_ENABLE = no            # MIDI controls
+AUDIO_ENABLE = no           # Audio output on port C6
+UNICODE_ENABLE = no         # Unicode
+BLUETOOTH_ENABLE = no       # Enable Bluetooth with the Adafruit EZ-Key HID
+RGBLIGHT_ENABLE = no        # Enable WS2812 RGB underlight.

--- a/quantum/keymap_common.c
+++ b/quantum/keymap_common.c
@@ -63,6 +63,9 @@ action_t action_for_key(uint8_t layer, keypos_t key)
         case KC_AUDIO_MUTE ... KC_BRIGHTNESS_DOWN:
             action.code = ACTION_USAGE_CONSUMER(KEYCODE2CONSUMER(keycode));
             break;
+        case KC_APPLE_FN:
+            action.code = ACTION_APPLE_FN();
+            break;
         case KC_MS_UP ... KC_MS_ACCEL2:
             action.code = ACTION_MOUSEKEY(keycode);
             break;

--- a/tmk_core/common.mk
+++ b/tmk_core/common.mk
@@ -114,6 +114,10 @@ ifeq ($(strip $(EXTRAKEY_ENABLE)), yes)
     SHARED_EP_ENABLE = yes
 endif
 
+ifeq ($(strip $(APPLE_FN_ENABLE)), yes)
+    TMK_COMMON_DEFS += -DAPPLE_FN_ENABLE
+endif
+
 ifeq ($(strip $(RAW_ENABLE)), yes)
     TMK_COMMON_DEFS += -DRAW_ENABLE
 endif

--- a/tmk_core/common/action.c
+++ b/tmk_core/common/action.c
@@ -362,6 +362,16 @@ void process_action(keyrecord_t *record, action_t action)
             }
             break;
 #endif
+#ifdef APPLE_FN_ENABLE
+        /* Apple Fn */
+        case ACT_APPLE_FN:
+            if (event.pressed) {
+                register_code(KC_APPLE_FN);
+            } else {
+                unregister_code(KC_APPLE_FN);
+            }
+            break;
+#endif
 #ifdef MOUSEKEY_ENABLE
         /* Mouse key */
         case ACT_MOUSEKEY:
@@ -776,6 +786,10 @@ void register_code(uint8_t code)
     else if IS_CONSUMER(code) {
         host_consumer_send(KEYCODE2CONSUMER(code));
     }
+    else if IS_APPLE_FN(code) {
+        add_key(code);
+        send_keyboard_report();
+    }
 
     #ifdef MOUSEKEY_ENABLE
       else if IS_MOUSEKEY(code) {
@@ -842,6 +856,11 @@ void unregister_code(uint8_t code)
     else if IS_CONSUMER(code) {
         host_consumer_send(0);
     }
+    else if IS_APPLE_FN(code) {
+        del_key(code);
+        send_keyboard_report();
+    }
+
     #ifdef MOUSEKEY_ENABLE
       else if IS_MOUSEKEY(code) {
         mousekey_off(code);
@@ -1007,6 +1026,7 @@ void debug_action(action_t action)
         case ACT_LMODS_TAP:         dprint("ACT_LMODS_TAP");         break;
         case ACT_RMODS_TAP:         dprint("ACT_RMODS_TAP");         break;
         case ACT_USAGE:             dprint("ACT_USAGE");             break;
+        case ACT_APPLE_FN:          dprint("ACT_APPLE_FN");          break;
         case ACT_MOUSEKEY:          dprint("ACT_MOUSEKEY");          break;
         case ACT_LAYER:             dprint("ACT_LAYER");             break;
         case ACT_LAYER_TAP:         dprint("ACT_LAYER_TAP");         break;

--- a/tmk_core/common/action_code.h
+++ b/tmk_core/common/action_code.h
@@ -51,7 +51,8 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
  * ACT_SWAP_HANDS(0110):
  * 0110|xxxx| keycode     Swap hands (keycode on tap, or options)
  *
- * 0111|xxxx xxxx xxxx    (reserved)
+ * ACT_APPLE_FN(0111):
+ * 0111|0000|0000|0000    Apple Fn
  *
  * Layer Actions(10xx)
  * -------------------
@@ -108,6 +109,8 @@ enum action_kind_id {
     ACT_MOUSEKEY        = 0b0101,
     /* One-hand Support */
     ACT_SWAP_HANDS      = 0b0110,
+    /* Apple Fn */
+    ACT_APPLE_FN        = 0b0111,
     /* Layer Actions */
     ACT_LAYER           = 0b1000,
     ACT_LAYER_TAP       = 0b1010, /* Layer  0-15 */
@@ -231,6 +234,7 @@ enum usage_pages {
 };
 #define ACTION_USAGE_SYSTEM(id)         ACTION(ACT_USAGE, PAGE_SYSTEM<<10 | (id))
 #define ACTION_USAGE_CONSUMER(id)       ACTION(ACT_USAGE, PAGE_CONSUMER<<10 | (id))
+#define ACTION_APPLE_FN()               ACTION(ACT_APPLE_FN, 0)
 #define ACTION_MOUSEKEY(key)            ACTION(ACT_MOUSEKEY, key)
 
 

--- a/tmk_core/common/keycode.h
+++ b/tmk_core/common/keycode.h
@@ -34,6 +34,7 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 #define IS_SPECIAL(code)         ((0xA5 <= (code) && (code) <= 0xDF) || (0xE8 <= (code) && (code) <= 0xFF))
 #define IS_SYSTEM(code)          (KC_PWR       <= (code) && (code) <= KC_WAKE)
 #define IS_CONSUMER(code)        (KC_MUTE      <= (code) && (code) <= KC_BRID)
+#define IS_APPLE_FN(code)        (KC_APFN      == (code))
 
 #define IS_FN(code)              (KC_FN0       <= (code) && (code) <= KC_FN31)
 
@@ -189,6 +190,9 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 #define KC_MRWD KC_MEDIA_REWIND
 #define KC_BRIU KC_BRIGHTNESS_UP
 #define KC_BRID KC_BRIGHTNESS_DOWN
+
+/* Apple Fn */
+#define KC_APFN KC_APPLE_FN
 
 /* System Specific */
 #define KC_BRMU KC_PAUSE
@@ -482,6 +486,9 @@ enum internal_special_keycodes {
   KC_MEDIA_REWIND,
   KC_BRIGHTNESS_UP,
   KC_BRIGHTNESS_DOWN,
+
+  /* Apple Fn */
+  KC_APPLE_FN,
 
   /* Fn keys */
   KC_FN0                  = 0xC0,

--- a/tmk_core/common/report.c
+++ b/tmk_core/common/report.c
@@ -215,6 +215,12 @@ void del_key_bit(report_keyboard_t* keyboard_report, uint8_t code)
  */
 void add_key_to_report(report_keyboard_t* keyboard_report, uint8_t key)
 {
+#ifdef APPLE_FN_ENABLE
+    if IS_APPLE_FN(key) {
+        keyboard_report->reserved = 1;
+        return;
+    }
+#endif
 #ifdef NKRO_ENABLE
     if (keyboard_protocol && keymap_config.nkro) {
         add_key_bit(keyboard_report, key);
@@ -230,6 +236,12 @@ void add_key_to_report(report_keyboard_t* keyboard_report, uint8_t key)
  */
 void del_key_from_report(report_keyboard_t* keyboard_report, uint8_t key)
 {
+#ifdef APPLE_FN_ENABLE
+    if IS_APPLE_FN(key) {
+        keyboard_report->reserved = 0;
+        return;
+    }
+#endif
 #ifdef NKRO_ENABLE
     if (keyboard_protocol && keymap_config.nkro) {
         del_key_bit(keyboard_report, key);

--- a/tmk_core/protocol/usb_descriptor.c
+++ b/tmk_core/protocol/usb_descriptor.c
@@ -68,9 +68,19 @@ const USB_Descriptor_HIDReport_Datatype_t PROGMEM KeyboardReport[] = {
         HID_RI_REPORT_SIZE(8, 0x01),
         HID_RI_INPUT(8, HID_IOF_DATA | HID_IOF_VARIABLE | HID_IOF_ABSOLUTE),
 
+#ifdef APPLE_FN_ENABLE
+        HID_RI_USAGE_PAGE(8, 0xFF), /* AppleVendor Top Case */
+        HID_RI_USAGE(8, 0x03), /* KeyboardFn */
+        HID_RI_LOGICAL_MINIMUM(8, 0x00),
+        HID_RI_LOGICAL_MAXIMUM(8, 0x01),
+        HID_RI_REPORT_COUNT(8, 0x01),
+        HID_RI_REPORT_SIZE(8, 0x08),
+        HID_RI_INPUT(8, HID_IOF_DATA | HID_IOF_VARIABLE | HID_IOF_ABSOLUTE),
+#else
         HID_RI_REPORT_COUNT(8, 0x01),
         HID_RI_REPORT_SIZE(8, 0x08),
         HID_RI_INPUT(8, HID_IOF_CONSTANT),  /* reserved */
+#endif
 
         HID_RI_USAGE_PAGE(8, 0x08), /* LEDs */
         HID_RI_USAGE_MINIMUM(8, 0x01), /* Num Lock */


### PR DESCRIPTION
Notable things:

* Laid out like an Apple compact aluminium keyboard
* Function keys work as "special" media/etc keys by default, use Fn key to toggle to F1, F2, etc

Mappings:

* Print Screen / Scroll Lock are unmapped
* Pause is the Power button
* `| is §±
* Insert is Apple Fn key (toggles function keys)
* #~ is \|
* \| is `~
* left windows key is left command
* left alt is left option
* Menu/App button (to right of space bar) is Keypad Enter
* right windows key is right command
* Alt Gr is right option